### PR TITLE
First step in namespace fix

### DIFF
--- a/Vostok.ClusterClient.Datacenters.Tests/AvoidInactiveDatacentersModifier_Tests.cs
+++ b/Vostok.ClusterClient.Datacenters.Tests/AvoidInactiveDatacentersModifier_Tests.cs
@@ -5,7 +5,9 @@ using NSubstitute;
 using NUnit.Framework;
 using Vostok.Datacenters;
 
-namespace Vostok.ClusterClient.Datacenters.Tests
+// ReSharper disable AssignNullToNotNullAttribute
+
+namespace Vostok.Clusterclient.Datacenters.Tests
 {
     [TestFixture]
     public class AvoidInactiveDatacentersModifier_Tests
@@ -34,8 +36,7 @@ namespace Vostok.ClusterClient.Datacenters.Tests
         public void Modify_should_not_modify_weight_when_datacenter_not_found()
         {
             datacenters.GetActiveDatacenters().Returns(new HashSet<string> {"dc"});
-            string result = null;
-            datacenters.GetDatacenterWeak(Arg.Any<string>()).Returns(result);
+            datacenters.GetDatacenterWeak(Arg.Any<string>()).Returns(null as string);
             modifier.Modify(new Uri("http://url.com/"), null, null, null, null, ref weight);
             weight.Should().Be(1.1);
         }

--- a/Vostok.ClusterClient.Datacenters.Tests/BoostLocalDatacentersModifier_Tests.cs
+++ b/Vostok.ClusterClient.Datacenters.Tests/BoostLocalDatacentersModifier_Tests.cs
@@ -4,7 +4,9 @@ using NSubstitute;
 using NUnit.Framework;
 using Vostok.Datacenters;
 
-namespace Vostok.ClusterClient.Datacenters.Tests
+// ReSharper disable AssignNullToNotNullAttribute
+
+namespace Vostok.Clusterclient.Datacenters.Tests
 {
     [TestFixture]
     public class BoostLocalDatacentersModifier_Tests

--- a/Vostok.ClusterClient.Datacenters.Tests/Vostok.ClusterClient.Datacenters.Tests.csproj
+++ b/Vostok.ClusterClient.Datacenters.Tests/Vostok.ClusterClient.Datacenters.Tests.csproj
@@ -6,6 +6,7 @@
     <TargetFrameworks>netcoreapp2.1;net471</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.1</TargetFrameworks>
     <LangVersion>7.2</LangVersion>
+    <RootNamespace>Vostok.Clusterclient.Datacenters.Tests</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.4.1" />

--- a/Vostok.ClusterClient.Datacenters/AvoidInactiveDatacentersModifier.cs
+++ b/Vostok.ClusterClient.Datacenters/AvoidInactiveDatacentersModifier.cs
@@ -7,7 +7,7 @@ using Vostok.Clusterclient.Core.Ordering.Storage;
 using Vostok.Clusterclient.Core.Ordering.Weighed;
 using Vostok.Datacenters;
 
-namespace Vostok.ClusterClient.Datacenters
+namespace Vostok.Clusterclient.Datacenters
 {
     /// <summary>
     /// <para>A weight modifier that applies zero weights for non-active datacenters.</para>
@@ -39,6 +39,19 @@ namespace Vostok.ClusterClient.Datacenters
         }
 
         public void Learn(ReplicaResult result, IReplicaStorageProvider storageProvider)
+        {
+        }
+    }
+}
+
+namespace Vostok.ClusterClient.Datacenters
+{
+    [PublicAPI]
+    [Obsolete("To be removed soon. Please use the version of this class from Vostok.Clusterclient.Datacenters namespace (notice the lowecase 'c').")]
+    public class AvoidInactiveDatacentersModifier : Clusterclient.Datacenters.AvoidInactiveDatacentersModifier
+    {
+        public AvoidInactiveDatacentersModifier([NotNull] IDatacenters datacenters)
+            : base(datacenters)
         {
         }
     }

--- a/Vostok.ClusterClient.Datacenters/BoostLocalDatacentersModifier.cs
+++ b/Vostok.ClusterClient.Datacenters/BoostLocalDatacentersModifier.cs
@@ -4,9 +4,10 @@ using JetBrains.Annotations;
 using Vostok.Clusterclient.Core.Model;
 using Vostok.Clusterclient.Core.Ordering.Storage;
 using Vostok.Clusterclient.Core.Ordering.Weighed;
+using Vostok.Clusterclient.Datacenters;
 using Vostok.Datacenters;
 
-namespace Vostok.ClusterClient.Datacenters
+namespace Vostok.Clusterclient.Datacenters
 {
     /// <summary>
     /// <para>A weight modifier that increases weight of replicas in local datacenter.</para>
@@ -49,6 +50,24 @@ namespace Vostok.ClusterClient.Datacenters
         }
 
         public void Learn(ReplicaResult result, IReplicaStorageProvider storageProvider)
+        {
+        }
+    }
+}
+
+namespace Vostok.ClusterClient.Datacenters
+{
+    [PublicAPI]
+    [Obsolete("To be removed soon. Please use the version of this class from Vostok.Clusterclient.Datacenters namespace (notice the lowecase 'c').")]
+    public class BoostLocalDatacentersModifier : Clusterclient.Datacenters.BoostLocalDatacentersModifier
+    {
+        public BoostLocalDatacentersModifier([NotNull] IDatacenters datacenters, double boostMultiplier = Constants.DefaultBoostMultiplier, double minimumWeightForBoosting = Constants.DefaultMinimumWeightForBoosting)
+            : base(datacenters, boostMultiplier, minimumWeightForBoosting)
+        {
+        }
+
+        public BoostLocalDatacentersModifier([NotNull] IDatacenters datacenters, [NotNull] Func<double> boostMultiplierProvider, [NotNull] Func<double> minimumWeightForBoostingProvider)
+            : base(datacenters, boostMultiplierProvider, minimumWeightForBoostingProvider)
         {
         }
     }

--- a/Vostok.ClusterClient.Datacenters/Constants.cs
+++ b/Vostok.ClusterClient.Datacenters/Constants.cs
@@ -1,4 +1,4 @@
-﻿namespace Vostok.ClusterClient.Datacenters
+﻿namespace Vostok.Clusterclient.Datacenters
 {
     internal static class Constants
     {

--- a/Vostok.ClusterClient.Datacenters/IWeighedReplicaOrderingBuilderExtensions.cs
+++ b/Vostok.ClusterClient.Datacenters/IWeighedReplicaOrderingBuilderExtensions.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using JetBrains.Annotations;
 using Vostok.Clusterclient.Core.Ordering.Weighed;
+using Vostok.Clusterclient.Datacenters;
 using Vostok.Datacenters;
 
-namespace Vostok.ClusterClient.Datacenters
+namespace Vostok.Clusterclient.Datacenters
 {
     [PublicAPI]
     public static class IWeighedReplicaOrderingBuilderExtensions
@@ -41,5 +42,41 @@ namespace Vostok.ClusterClient.Datacenters
         {
             self.AddModifier(new BoostLocalDatacentersModifier(datacenters, boostMultiplierProvider, minimumWeightForBoostingProvider));
         }
+    }
+}
+
+namespace Vostok.ClusterClient.Datacenters
+{
+    [PublicAPI]
+    public static class IWeighedReplicaOrderingBuilderExtensions
+    {
+        /// <summary>
+        /// Adds a <see cref="AvoidInactiveDatacentersModifier"/> that will apply zero weights for non-active datacenters.
+        /// </summary>
+        [Obsolete("To be removed soon. Please use the version of this extension from Vostok.Clusterclient.Datacenters namespace (notice the lowecase 'c').")]
+        public static void SetupAvoidInactiveDatacentersWeightModifier([NotNull] this IWeighedReplicaOrderingBuilder self, [NotNull] IDatacenters datacenters)
+            => Clusterclient.Datacenters.IWeighedReplicaOrderingBuilderExtensions.SetupAvoidInactiveDatacentersWeightModifier(self, datacenters);
+
+        /// <summary>
+        /// Adds a <see cref="BoostLocalDatacentersModifier"/> that will increase weight of replicas in local datacenter.
+        /// </summary>
+        [Obsolete("To be removed soon. Please use the version of this extension from Vostok.Clusterclient.Datacenters namespace (notice the lowecase 'c').")]
+        public static void SetupBoostLocalDatacentersWeightModifier(
+            [NotNull] this IWeighedReplicaOrderingBuilder self,
+            [NotNull] IDatacenters datacenters,
+            double boostMultiplier = Constants.DefaultBoostMultiplier,
+            double minimumWeightForBoosting = Constants.DefaultMinimumWeightForBoosting)
+            => Clusterclient.Datacenters.IWeighedReplicaOrderingBuilderExtensions.SetupBoostLocalDatacentersWeightModifier(self, datacenters, boostMultiplier, minimumWeightForBoosting);
+
+        /// <summary>
+        /// Adds a <see cref="BoostLocalDatacentersModifier"/> that will increase weight of replicas in local datacenter.
+        /// </summary>
+        [Obsolete("To be removed soon. Please use the version of this extension from Vostok.Clusterclient.Datacenters namespace (notice the lowecase 'c').")]
+        public static void SetupBoostLocalDatacentersWeightModifier(
+            [NotNull] this IWeighedReplicaOrderingBuilder self,
+            [NotNull] IDatacenters datacenters,
+            [NotNull] Func<double> boostMultiplierProvider,
+            [NotNull] Func<double> minimumWeightForBoostingProvider)
+            => Clusterclient.Datacenters.IWeighedReplicaOrderingBuilderExtensions.SetupBoostLocalDatacentersWeightModifier(self, datacenters, boostMultiplierProvider, minimumWeightForBoostingProvider);
     }
 }

--- a/Vostok.ClusterClient.Datacenters/Vostok.ClusterClient.Datacenters.csproj
+++ b/Vostok.ClusterClient.Datacenters/Vostok.ClusterClient.Datacenters.csproj
@@ -6,6 +6,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Configurations>Debug;Release</Configurations>
     <LangVersion>7.2</LangVersion>
+    <RootNamespace>Vostok.Clusterclient.Datacenters</RootNamespace>
   </PropertyGroup>
   <PropertyGroup>
     <VersionPrefix>0.1.3</VersionPrefix>


### PR DESCRIPTION
Public APIs now exist simultaneously in Vostok.ClusterClient.Datacenters and Vostok.Clusterclient.Datacenters namespaces.

https://github.com/vostok/clusterclient.datacenters/issues/1